### PR TITLE
♻️ No more popcorn UI on SSR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nextjs-layout-waterfall",
+  "name": "nextjs-suspense",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nextjs-layout-waterfall",
+      "name": "nextjs-suspense",
       "version": "0.1.0",
       "dependencies": {
         "next": "14.2.3",

--- a/src/app/item/[itemId]/loading.jsx
+++ b/src/app/item/[itemId]/loading.jsx
@@ -1,3 +1,0 @@
-export default function Loading() {
-  return <p>Loading...</p>;
-}

--- a/src/app/item/[itemId]/page.jsx
+++ b/src/app/item/[itemId]/page.jsx
@@ -1,27 +1,43 @@
-import { cache } from 'react';
+import { headers } from "next/headers";
+import { cache } from "react";
+import * as React from "react";
 
 const items = [
-  { id: '1', name: 'item-one', detail: 'some detail for item one' },
-  { id: '2', name: 'item-two', detail: 'some detail for item two' },
-  { id: '3', name: 'item-three', detail: 'some detail for item three' },
-  { id: '4', name: 'item-four', detail: 'some detail for item four' },
-  { id: '5', name: 'item-five', detail: 'some detail for item five' },
+	{ id: "1", name: "item-one", detail: "some detail for item one" },
+	{ id: "2", name: "item-two", detail: "some detail for item two" },
+	{ id: "3", name: "item-three", detail: "some detail for item three" },
+	{ id: "4", name: "item-four", detail: "some detail for item four" },
+	{ id: "5", name: "item-five", detail: "some detail for item five" },
 ];
 
 const getData = cache(async (id) => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve({ data: items.find((item) => item.id === id) });
-    }, 500);
-  });
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve({ data: items.find((item) => item.id === id) });
+		}, 500);
+	});
 });
 
+function isSSRLoad() {
+	return headers().get("accept").includes("text/html");
+}
+
 export default async function Item({ params }) {
-  const response = await getData(params.itemId);
-  return (
-    <div>
-      <h1>{response.data.name}</h1>
-      <p>{response.data.detail}</p>
-    </div>
-  );
+	return isSSRLoad() ? (
+		<Content params={params} />
+	) : (
+		<React.Suspense fallback={<p>Loading...</p>}>
+			<Content params={params} />
+		</React.Suspense>
+	);
+}
+
+async function Content({ params }) {
+	const response = await getData(params.itemId);
+	return (
+		<div>
+			<h1>{response.data.name}</h1>
+			<p>{response.data.detail}</p>
+		</div>
+	);
 }


### PR DESCRIPTION
This is taking advantage of the fact that browsers send an `accept: text/html` header for MPA navigation, while on client side navigation, nextjs set accept header to `*/*`. So depending on that value we show the Suspense boundary or not. 

The more reliable way I have tested is by passing `RSC: 1` header and that's what nextjs really use under the hood to either send the RSC payload (used for client side navigation) or the HTML content. 

https://github.com/jjenzz/nextjs-suspense/assets/38298743/d22734fb-6640-4262-8038-db4d5892dfc5

